### PR TITLE
Display a "work in progress" spinner during slow operations

### DIFF
--- a/django_restic_gui/templates/base.html
+++ b/django_restic_gui/templates/base.html
@@ -22,14 +22,24 @@
 <meta name="theme-color" content="#ffffff">
 <link href="{% static 'css/style.css' %}" rel="stylesheet">
 <style>
-.nav-link svg {
-    margin-top: -3px;
-}
+    .nav-link svg {
+        margin-top: -3px;
+    }
+    body.wip {
+        opacity: 0.5;
+    }
+    body.wip #wip-spinner {
+        display: block !important;
+        margin: 0 20px;
+    }
 </style>
 {% endblock %}
 
 {% block bootstrap4_extra_script %}
 {{ block.super }}
+<script>
+    function wip() {$('body').addClass('wip')}
+</script>
 {% endblock %}
 
 {% block bootstrap4_title %}Restic GUI{% endblock %}
@@ -38,6 +48,9 @@
 
 <!-- Content -->
 <nav class="navbar navbar-expand-md navbar-light bg-light">
+    <div id="wip-spinner" style="display: none;"; class="spinner-border" role="status">
+        <span class="sr-only">Loading...</span>
+    </div>
     <a class="navbar-brand" href="{% url 'home' %}">
         <svg width="1.2em" height="1.2em" viewBox="0 0 16 16" class="bi bi-file-earmark-lock" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path d="M4 0h5.5v1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5h1V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2z"/>

--- a/repository/templates/repository/file_browse_icon.html
+++ b/repository/templates/repository/file_browse_icon.html
@@ -49,7 +49,7 @@ $(document).ready(function() {
 </div>
 
 <div class="view_switch">
-    <a href="{% url 'repository:browse' object.id 'list' %}?id={{ snapshot.short_id }}&path={{ current.path }}">
+    <a onclick="wip()" href="{% url 'repository:browse' object.id 'list' %}?id={{ snapshot.short_id }}&path={{ current.path }}">
         <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-list-ul" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" d="M5 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5zm-3 1a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm0 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm0 4a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
         </svg>
@@ -74,7 +74,7 @@ $(document).ready(function() {
                     </svg>
                 </a>
                 {% if path.type == 'dir' %}
-                    <a href="{% url 'repository:browse' object.id 'icon' %}?id={{ snapshot.short_id }}&path={{ path.path }}">
+                    <a onclick="wip()" href="{% url 'repository:browse' object.id 'icon' %}?id={{ snapshot.short_id }}&path={{ path.path }}">
                         <svg class="card-img" width="2em" height="2em" viewBox="0 0 16 16" class="bi bi-folder" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                           <path d="M9.828 4a3 3 0 0 1-2.12-.879l-.83-.828A1 1 0 0 0 6.173 2H2.5a1 1 0 0 0-1 .981L1.546 4h-1L.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3v1z"/>
                           <path fill-rule="evenodd" d="M13.81 4H2.19a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91h10.348a1 1 0 0 0 .995-.91l.637-7A1 1 0 0 0 13.81 4zM2.19 3A2 2 0 0 0 .198 5.181l.637 7A2 2 0 0 0 2.826 14h10.348a2 2 0 0 0 1.991-1.819l.637-7A2 2 0 0 0 13.81 3H2.19z"/>

--- a/repository/templates/repository/file_browse_list.html
+++ b/repository/templates/repository/file_browse_list.html
@@ -49,7 +49,7 @@ $(document).ready(function() {
 </div>
 
 <div class="view_switch">
-    <a href="{% url 'repository:browse' object.id 'icon' %}?id={{ snapshot.short_id }}&path={{ current.path }}">
+    <a onclick="wip()" href="{% url 'repository:browse' object.id 'icon' %}?id={{ snapshot.short_id }}&path={{ current.path }}">
         <svg width="1.5em" height="1.5em" viewBox="0 0 16 16" class="bi bi-list-ul" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" d="M4 2H2v2h2V2zm1 12v-2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1zm0-5V7a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1zm0-5V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1zm5 10v-2a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1zm0-5V7a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1zm0-5V2a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1zM9 2H7v2h2V2zm5 0h-2v2h2V2zM4 7H2v2h2V7zm5 0H7v2h2V7zm5 0h-2v2h2V7zM4 12H2v2h2v-2zm5 0H7v2h2v-2zm5 0h-2v2h2v-2zM12 1a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1h-2zm-1 6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V7zm1 4a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1h-2z"/>
         </svg>
@@ -87,7 +87,7 @@ $(document).ready(function() {
                     </td>
                     <td>
                         {% if path.type == 'dir' %}
-                            <a href="{% url 'repository:browse' object.id 'list' %}?id={{ snapshot.short_id }}&path={{ path.path }}">
+                            <a onclick="wip()" href="{% url 'repository:browse' object.id 'list' %}?id={{ snapshot.short_id }}&path={{ path.path }}">
                                 {{ path.path }}
                             </a>
                         {% else %}

--- a/repository/templates/repository/repository_list.html
+++ b/repository/templates/repository/repository_list.html
@@ -83,7 +83,7 @@ $(document).ready(function() {
                     {% for repo in repository_list %}
                     <tr>
                         <td>
-                            <a class="tool" href="{% url 'repository:snapshots' repo.id %}" title="{% trans 'Snapshots' %}">
+                            <a class="tool" onclick="wip()" href="{% url 'repository:snapshots' repo.id %}" title="{% trans 'Snapshots' %}">
                                 {{ repo.name }}
                             </a>
                         </td>

--- a/repository/templates/repository/repository_snapshots.html
+++ b/repository/templates/repository/repository_snapshots.html
@@ -64,7 +64,7 @@ $(document).ready(function() {
                     {% for path in snap.paths %}
                     <ul class="list-group list-group-flush">
                         <li class="list-group-item">
-                            <a href="{% url 'repository:browse' object.id 'icon' %}?id={{ snap.short_id }}&path={{ path }}">
+                            <a onclick="wip()" href="{% url 'repository:browse' object.id 'icon' %}?id={{ snap.short_id }}&path={{ path }}">
                                 {{ path }}
                             </a>
                             <i class="float-right restore" title="{% trans 'Restore' %}" data-url="{% url 'repository:restore' object.id 'icon' %}" data-id="{{ snap.short_id }}" data-path="{{ path }}">


### PR DESCRIPTION
Fetching data from remote Restic repos can be rather slow, so giving a feedback that something is going on might be appropriate.
The solution adopted in thie PR is very rude, and requires to manually add `onclick="wip()"` to all link responsible of potentially slow operations
