### PR TITLE
Using a separate chart for every Repo

### DIFF
--- a/repository/chart_utils.py
+++ b/repository/chart_utils.py
@@ -5,31 +5,33 @@ from repository.models import RepoSize
 
 def repo_datasets(index, repo):
 
-    def color_code(index, opacity):
-        h = ((index * 60) % 360) / 360.0
-        l = s = 0.9
-        r, g, b = colorsys.hsv_to_rgb(h, l, s)
-        return "rgba(%d,%d,%d,%.1f)" % (int(r * 255), int(g * 255), int(b * 255), opacity)
+    # def color_code(index, opacity):
+    #     h = ((index * 60) % 360) / 360.0
+    #     l = s = 0.9
+    #     r, g, b = colorsys.hsv_to_rgb(h, l, s)
+    #     return "rgba(%d,%d,%d,%.1f)" % (int(r * 255), int(g * 255), int(b * 255), opacity)
 
-    fg = color_code(index, 1.0)
-    bg = color_code(index, 0.1)
+    # fg = color_code(index, 1.0)
+    # bg = color_code(index, 0.1)
+    fg = "#007bff"
+    bg = "#007bff"
 
     datasets = [{
-        'label': '"%s" %s' % (repo.name, _('size [GB]')),
+        'label': str(_('size [GB]')),
         'yAxisID': 'y1',
         'fill': False,
-        'pointRadius': 3.0,
+        'pointRadius': 2.0,
         'borderColor': fg,
         'pointBackgroundColor': fg,
         'backgroundColor': bg,
         'data': [],
     }, {
-        'label': '"%s" %s' % (repo.name, _('files count')),
+        'label': str(_('K files')),
         'yAxisID': 'y2',
         'fill': False,
         'pointRadius': 2.0,
-        'borderDash': [1, 3],
         'borderColor': fg,
+        'borderDash': [1, 1],
         'pointBackgroundColor': fg,
         'backgroundColor': bg,
         'data': [],
@@ -47,7 +49,7 @@ def repo_datasets(index, repo):
         })
         datasets[1]['data'].append({
             'x': row.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-            'y': row.file_count
+            'y': row.file_count / 1000
         })
 
     return datasets, time_unit

--- a/repository/static/repository/css/repolist.css
+++ b/repository/static/repository/css/repolist.css
@@ -15,3 +15,7 @@
     color:#666666;
     background-color: #eeeeee;
 }
+
+.chart-container {
+    border: 1px solid red;
+}

--- a/repository/templates/repository/repository_chart.html
+++ b/repository/templates/repository/repository_chart.html
@@ -81,13 +81,20 @@
                                 position: 'right',
                                 title: {
                                     display: true,
-                                    text: 'n.'
+                                    text: 'K files'
                                 }
                             }
                         },
                         responsive: true,
-                        legend: {
-                            position: 'top',
+                        plugins: {
+                            legend: {
+                                position: 'top',
+                                display: false
+                            },
+                            title: {
+                                display: true,
+                                text: '{{repository}}'
+                            }
                         }
                     }
                 });

--- a/repository/templates/repository/repository_list.html
+++ b/repository/templates/repository/repository_list.html
@@ -28,53 +28,51 @@ $(document).ready(function() {
         });
     });
 
-    var $repositoryChart = $("#repository-chart");
-    $.ajax({
-        url: $repositoryChart.data("url"),
-        success: function (data) {
-            var ctx = $repositoryChart[0].getContext("2d");
-            //console.log(data);
-            new Chart(ctx, {
-                type: 'line',
-                data: {
-                     datasets: data.datasets
-                },
-                options: {
-                    scales: {
-                        xAxes: {
-                            type: 'time',
-                            time: {
-                                unit: data.time_unit
-                            },
-                            position: 'bottom'
+    {% for chart_dataset in chart_datasets %}
+        var $repositoryChart = $("#repository-chart-{{forloop.counter0}}");
+        var ctx = $repositoryChart[0].getContext("2d");
+        new Chart(ctx, {
+            type: 'line',
+            data: {
+                 datasets: {{ chart_dataset.datasets|safe }}
+            },
+            options: {
+                scales: {
+                    xAxes: {
+                        type: 'time',
+                        time: {
+                            unit: '{{ chart_dataset.time_unit }}'
                         },
-                        y1: {
-                            type: 'linear',
+                        position: 'bottom'
+                    },
+                    y1: {
+                        type: 'linear',
+                        display: true,
+                        position: 'left',
+                        title: {
                             display: true,
-                            position: 'left',
-                            title: {
-                                display: true,
-                                text: 'GB'
-                            }
-                        },
-                        y2: {
-                            type: 'linear',
-                            display: true,
-                            position: 'right',
-                            title: {
-                                display: true,
-                                text: 'n.'
-                            }
+                            text: 'GB'
                         }
                     },
-                    responsive: true,
+                    y2: {
+                        type: 'linear',
+                        display: true,
+                        position: 'right',
+                        title: {
+                            display: true,
+                            text: 'K files'
+                        }
+                    }
+                },
+                responsive: true,
+                plugins: {
                     legend: {
-                        position: 'top',
+                        display: false
                     }
                 }
-            });
-        }
-    });
+            }
+        });
+    {% endfor %}
 
 });
 </script>
@@ -90,7 +88,6 @@ $(document).ready(function() {
 <div class="modal fade" tabindex="-1" role="dialog" id="backupModal">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
-
         </div>
     </div>
 </div>
@@ -121,8 +118,19 @@ $(document).ready(function() {
 </div>
 {% endif %}
 
-<div id="container" style="width: 100%;">
-    <canvas id="repository-chart" data-url="{% url 'repository:get_charts' %}"></canvas>
+<div class="row">
+    {% for chart_dataset in chart_datasets %}
+    <div class="col-xs-12 col-sm-6 col-lg-4">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title"><a href="{% url 'repository:chart' chart_dataset.repo.id %}">{{ chart_dataset.repo }}</a></h5>
+                <p class="card-text">
+                    <canvas id="repository-chart-{{forloop.counter0}}"></canvas>
+                </p>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
 </div>
 
 <div class="row">

--- a/repository/urls.py
+++ b/repository/urls.py
@@ -17,5 +17,4 @@ urlpatterns = [
     path('journal/', views.JournalView.as_view(), name='journal'),
     path('chart/<int:pk>/', views.RepositoryChart.as_view(), name='chart'),
     path('get_chart/<int:repo_id>/', views.repository_chart, name='get_chart'),
-    path('get_charts/', views.repository_charts, name='get_charts'),
 ]


### PR DESCRIPTION
Due to the very different sizes of repos, collecting them in a single chart doesn't help much.

<img width="1185" alt="Screen Shot 2022-07-02 at 12 34 55" src="https://user-images.githubusercontent.com/299854/176997085-c17dea8e-9d6f-4b2c-91c2-3c026a7c4458.png">

Using separate charts seems more usefull to me.

<img width="898" alt="Screen Shot 2022-07-02 at 12 14 40" src="https://user-images.githubusercontent.com/299854/176996871-e50df0e5-ba61-4be3-9671-f52fbe0cdebd.png">


